### PR TITLE
Add issues to GitHub Management project automatically

### DIFF
--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to UTBot Site project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/UnitTestBot/projects/5
+          github-token: ${{ secrets.COPY_ISSUE_TO_PROJECT }}


### PR DESCRIPTION
# Description

There is added a script automatically adding issues to the GitHub Management project.

Fixes #35

## Type of Change

Workflow file was added.

## Visual proofs (screenshots, logs, images)

Not attached.

## How Has This Been Tested?

The script works correctly in other project repositories.
