### PR TITLE
Remove `sudo` from scripts updating docs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,4 +2,4 @@
 
 sh prepare_docs_for_build.sh
 cd ..
-sudo gatsby build
+gatsby build

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -2,4 +2,4 @@
 
 sh prepare_docs_for_build.sh
 cd ..
-sudo gatsby develop
+gatsby develop


### PR DESCRIPTION
# Description

The fix removes all of the `sudo` notes in the scripts updating docs.

Fixes #34

## Type of Change

The changes were added into scripts updating docs.

## Visual proofs (screenshots, logs, images)

Not attached.

## How Has This Been Tested?

Site with the corresponding changes builds on fork.
