### PR TITLE
Fix too transparent menu #107

### DIFF
--- a/src/pages/styles/index.module.css
+++ b/src/pages/styles/index.module.css
@@ -15,6 +15,7 @@
 }
 
 .topContainer {
+  padding-top: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/src/utils/colors.css
+++ b/src/utils/colors.css
@@ -6,6 +6,12 @@
   --editor-minimap-bg: #232323;
   --dark-green-bg: rgb(1, 14, 1);
   --light-gree-bg: rgb(2, 45, 16);
+  --dark-green-bg: rgb(1, 14, 1);
+  --light-gree-bg: rgb(2, 45, 16);
+  --nav-link-selected: #399D53;
+  --demo-pg-dropdown-menu-bg: rgb(1, 14, 1);
+  --demo-pg-dropdown-menu-item: rgba(255, 255, 255, 0.73);
+  --demo-pg-dropdown-menu-item-hover: rgb(6, 49, 8);
 }
 
 #___gatsby {


### PR DESCRIPTION
# Description

Changes fix too transparent menu.

Fixes #107

## Type of Change

Add removed colors.

## Visual proofs (screenshots, logs, images)

Not attached.

## How Has This Been Tested?

It was tested locally and in Chrome on current site version.
