### PR TITLE
Fix demo page bug with NavDrodown

### DIFF
--- a/src/components/header.module.css
+++ b/src/components/header.module.css
@@ -42,6 +42,7 @@
 }
 
 .brand {
+  position: absolute;
   align-self: flex-start;
 }
 

--- a/src/pages/styles/utbot-mobile.module.css
+++ b/src/pages/styles/utbot-mobile.module.css
@@ -24,7 +24,7 @@
 }
 
 .toolbar a {
-  padding: 12px;
+  padding: 7px;
 }
 
 .codeEditor {
@@ -52,12 +52,12 @@
 
 @media screen and (min-width: 291px) and (max-width: 330px) {
   .toolbar a {
-    padding: 6px;
+    padding: 4px;
   }
 }
 
 @media screen and (max-width: 290px) {
   .toolbar a {
-    padding: 3px;
+    padding: 2px;
   }
 }

--- a/src/pages/utbot.jsx
+++ b/src/pages/utbot.jsx
@@ -240,6 +240,9 @@ const UTBotOnlinePage = () => {
       <NavDropdown.Item
         onClick={() => {
           setSourceCode(example.code);
+          if (window.screen.width < minDesktopWidth) {
+            hideDropdownExamples();
+          }
         }}
       >
         {example.name}
@@ -303,6 +306,7 @@ const UTBotOnlinePage = () => {
                       if (language != lang) {
                         setSourceCode(languageToSnippet(lang));
                       }
+                      hideDropdownLanguages();
                     }}
                   >
                     {languageToString(lang)}


### PR DESCRIPTION
# Description

On mobile phones NavDropdowns with Examples and Languages do not close on click. The PR fixes it.

Fixes # (issue)

## Type of Change

Fixes in demo page for mobile.

## Visual proofs (screenshots, logs, images)

Not attached.

## How Has This Been Tested?

It was tested on local machine in Chrome.
