### PR TITLE
Gifs and images are stretched on wide screens

### DIFF
--- a/src/components/exampleCard/example-card.module.css
+++ b/src/components/exampleCard/example-card.module.css
@@ -17,7 +17,7 @@
 
 .img {
   min-width: 450px;
-  width: 550px;
+  width: 100%;
 }
 
 @media screen and (min-width: 1200px) {

--- a/src/components/gif.jsx
+++ b/src/components/gif.jsx
@@ -1,11 +1,10 @@
 import React from "react";
-import cn from "classnames";
 import * as styles from "./gif.module.css";
 
 export default function Gif({ src, alt, className, width }) {
   return (
     <div className={styles.container}>
-      <img width={width} src={src} alt={alt} className={cn(className)} />
+      <img width={width} src={src} alt={alt} className={className} />
     </div>
   );
 }

--- a/src/components/gif.module.css
+++ b/src/components/gif.module.css
@@ -3,7 +3,6 @@
   max-width: 90vw;
 
   width: calc(50% - 2vw);
-  display: flex;
 }
 
 @media screen and (max-width: 1199px) {


### PR DESCRIPTION
# Description

Changes in styles in order not to stretch images on wide screens.

Fixes #140 

## Type of Change

Changes in styles.

## Visual proofs (screenshots, logs, images)

Not attached.

## How Has This Been Tested?

It was tested locally in Chrome (WSL 2 on Windows 10).