### PR TITLE
Languages on Demo page: C_SHARP added, KOTLIN removed

### DIFF
--- a/UTBotSiteTest/src/main/java/org/utbot/site/enums/Language.java
+++ b/UTBotSiteTest/src/main/java/org/utbot/site/enums/Language.java
@@ -5,10 +5,10 @@ public enum Language {
     C("C"),
     CPP("C++"),
     JAVA("Java"),
+    C_SHARP("C#"),
     GO("Go"),
     JAVASCRIPT("JavaScript"),
-    PYTHON("Python"),
-    KOTLIN("Kotlin");
+    PYTHON("Python");
 
     private final String language;
     Language(String language) {

--- a/UTBotSiteTest/src/test/java/org/utbot/site/pages/DemoPageTest.java
+++ b/UTBotSiteTest/src/test/java/org/utbot/site/pages/DemoPageTest.java
@@ -13,7 +13,7 @@ import static org.utbot.site.pages.DemoPage.*;
 public class DemoPageTest extends UTBotSiteTest {
 
     @ParameterizedTest
-    @CsvSource({ "C, 20", "CPP, 4", "JAVA, 13", "GO, 7", "JAVASCRIPT, 6", "PYTHON, 7", "KOTLIN, 1" })
+    @CsvSource({ "C, 20", "CPP, 4", "C_SHARP, 6", "JAVA, 13", "GO, 7", "JAVASCRIPT, 6", "PYTHON, 7" })
     public void checkExamplesArePresent(Language language, int minimalNumberOfExamples) {
         demoPage.open();
         languageDropdown.select(language.getName());


### PR DESCRIPTION
# Description

Languages on demo page: C_SHARP added, KOTLIN removed.
DemoPageTest corrected respectively.

## Type of Change

Test scope correction for the Demo page.

## Visual proofs (screenshots, logs, images)

![image](https://user-images.githubusercontent.com/37301492/213134435-8ca22417-dae8-416e-acda-c0c89a7fe517.png)

## How Has This Been Tested?

Local test run for all tests.
